### PR TITLE
Add missing pear lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ See the README there, but briefly:
    binaries on the vips website. For example, on Debian:
 
    ```
-   sudo apt-get install libvips-dev
+   sudo apt-get install libvips-dev php-pear
    ```
 
    Or macOS:


### PR DESCRIPTION
```pecl install vips

Command 'pecl' not found, but can be installed with:

apt install php-pear
```

after adding pear all works fine