### PR TITLE
Allowed for psr/log 2.0 and 3.0 to be installed as well

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
         }
     ],
     "require": {
-        "php": ">=7.1",
+        "php": ">=7.2",
         "ext-vips": ">=0.1.2",
-        "psr/log": "^1.1.3"
+        "psr/log": "^1.1.3|^2.0|^3.0"
     },
     "require-dev": {
         "php-parallel-lint/php-parallel-lint": "^1.2",

--- a/src/DebugLogger.php
+++ b/src/DebugLogger.php
@@ -69,7 +69,7 @@ class DebugLogger implements LoggerInterface
      *
      * @return void
      */
-    public function log($level, $message, array $context = [])
+    public function log($level, $message, array $context = []): void
     {
         // `Vips\Image` to string convert
         array_walk_recursive($context, function (&$value) {

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -33,7 +33,7 @@ class LoggerTest extends TestCase
              *
              * @return void
              */
-            public function log($level, $message, array $context = array())
+            public function log($level, $message, array $context = array()): void
             {
                 // Do logging logic here.
             }


### PR DESCRIPTION
This PR allows for any current psr/log version to be installed. I did have to bump the PHP version to 7.2 because of [partial contravariance](https://www.php.net/manual/en/language.oop5.variance.php). Tests are passing, but there might be an issue with phpdocumentor/phpdocumentor as it still requires psr/log v1. Wasn't sure how to handle that.

fixes #128