### PR TITLE
Explicitly unset images during `tearDown()`

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -781,6 +781,9 @@ EOS;
         self::$gobject = \FFI::cdef($gobject_decls, $gobject_libname);
         self::$vips = \FFI::cdef($vips_decls, $vips_libname);
 
+        # Useful for debugging
+        # self::$vips->vips_leak_set(1);
+
         # force the creation of some types we need
         self::$vips->vips_blend_mode_get_type();
         self::$vips->vips_interpretation_get_type();

--- a/tests/ConvenienceTest.php
+++ b/tests/ConvenienceTest.php
@@ -24,6 +24,12 @@ class ConvenienceTest extends TestCase
         $this->pixel = $this->image->getpoint(0, 0);
     }
 
+    protected function tearDown(): void
+    {
+        unset($this->image);
+        unset($this->pixel);
+    }
+
     public function testVipsBandjoin()
     {
         $image = Vips\Image::newFromArray([[1, 2, 3], [4, 5, 6]]);

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -12,16 +12,15 @@ class ExceptionTest extends TestCase
      */
     private $image;
 
-    /**
-     * The original value of pixel (0, 0).
-     */
-    private $pixel;
-
     protected function setUp(): void
     {
         $filename = __DIR__ . '/images/img_0076.jpg';
         $this->image = Vips\Image::newFromFile($filename);
-        $this->pixel = $this->image->getpoint(0, 0);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($this->image);
     }
 
     public function testVipsNewFromFileException()

--- a/tests/MetaTest.php
+++ b/tests/MetaTest.php
@@ -26,6 +26,12 @@ class MetaTest extends TestCase
         $this->png_image = Vips\Image::newFromFile($png_filename);
     }
 
+    protected function tearDown(): void
+    {
+        unset($this->image);
+        unset($this->png_image);
+    }
+
     public function testVipsSetGet()
     {
         $this->image->poop = 'banana';

--- a/tests/ShortcutTest.php
+++ b/tests/ShortcutTest.php
@@ -37,6 +37,12 @@ class ShortcutTest extends TestCase
         $this->pixel = $this->image->getpoint(0, 0);
     }
 
+    protected function tearDown(): void
+    {
+        unset($this->image);
+        unset($this->pixel);
+    }
+
     public function testVipsPow()
     {
         $real = self::mapNumeric($this->pixel, function ($value) {


### PR DESCRIPTION
To facilitate debugging of possible refleaks.

See: https://github.com/libvips/php-vips/issues/149#issuecomment-1188893993.