### PR TITLE
Fix `var_dump()` of instances

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -346,6 +346,20 @@ typedef uint64_t guint64;
 typedef int64_t gint64;
 
 typedef $gtype GType;
+
+typedef struct _GData GData;
+
+typedef struct _GTypeClass GTypeClass;
+
+typedef struct _GTypeInstance {
+    GTypeClass *g_class;
+} GTypeInstance;
+
+typedef struct _GObject {
+    GTypeInstance g_type_instance;
+    unsigned int ref_count;
+    GData *qdata;
+} GObject;
 EOS;
 
         // GLib declarations
@@ -360,14 +374,6 @@ typedef struct _GValue {
     GType g_type;
     guint64 data[2];
 } GValue;
-
-typedef struct _GData GData;
-
-typedef struct _GTypeClass GTypeClass;
-
-typedef struct _GTypeInstance {
-    GTypeClass *g_class;
-} GTypeInstance;
 
 typedef struct _GParamSpec {
     GTypeInstance g_type_instance;
@@ -385,12 +391,6 @@ typedef struct _GParamSpec {
     unsigned int ref_count;
     unsigned int param_id;
 } GParamSpec;
-
-typedef struct _GObject {
-    GTypeInstance g_type_instance;
-    unsigned int ref_count;
-    GData *qdata;
-} GObject;
 
 const char* g_type_name (GType gtype);
 GType g_type_from_name (const char* name);
@@ -478,8 +478,7 @@ EOS;
 typedef struct _VipsImage VipsImage;
 typedef struct _VipsProgress VipsProgress;
 
-// Defined in GObject, just typedef to void*
-typedef void* GObject;
+// Defined in GObject, just typedef to void
 typedef void GParamSpec;
 typedef void GValue;
 


### PR DESCRIPTION
Test case:
```php
<?php

require 'vendor/autoload.php';

use Jcupitt\Vips;

$image = Vips\Image::black(100, 100);
var_dump($image);

$operation = Vips\VipsOperation::newFromName('black');
var_dump($operation);

$gvalue = new Vips\GValue();
var_dump($gvalue);
```

This would previously fail with this segfault (noticed while debugging #142):
<details>
  <summary>gdb backtrace</summary>
  
```bash
Core was generated by `php-fpm:'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00007fb6d1c0e3c5 in zend_ffi_cdata_to_zval () from /usr/local/lib/php/extensions/debug-non-zts-20190902/ffi.so
(gdb) bt
#0  0x00007fb6d1c0e3c5 in zend_ffi_cdata_to_zval () at /usr/local/lib/php/extensions/debug-non-zts-20190902/ffi.so
#1  0x00007fb6d1c12495 in zend_ffi_cdata_get_debug_info () at /usr/local/lib/php/extensions/debug-non-zts-20190902/ffi.so
#2  0x0000557ebd168ee7 in zend_std_get_properties_for (obj=0x7fb6d1aeca00, purpose=ZEND_PROP_PURPOSE_DEBUG) at /usr/src/php/Zend/zend_object_handlers.c:1884
#3  0x0000557ebd168ff8 in zend_get_properties_for (obj=0x7fb6d1aeca00, purpose=ZEND_PROP_PURPOSE_DEBUG) at /usr/src/php/Zend/zend_object_handlers.c:1912
#4  0x0000557ebcfae6cf in php_var_dump (struc=0x7fb6d1aeca00, level=9) at /usr/src/php/ext/standard/var.c:163
#5  0x0000557ebcfae18a in php_object_property_dump (prop_info=0x0, zv=0x7fb6d1aeca00, index=9230944749267754699, key=0x7fb6d1b11960, level=7) at /usr/src/php/ext/standard/var.c:87
#6  0x0000557ebcfae8b4 in php_var_dump (struc=0x7fb6d1ac3140, level=7) at /usr/src/php/ext/standard/var.c:184
#7  0x0000557ebcfae18a in php_object_property_dump (prop_info=0x0, zv=0x7fb6d1ac3140, index=13372646034477452195, key=0x7fb6d1adf190, level=5) at /usr/src/php/ext/standard/var.c:87
#8  0x0000557ebcfae8b4 in php_var_dump (struc=0x7fb6d1a72348, level=5) at /usr/src/php/ext/standard/var.c:184
#9  0x0000557ebcfae18a in php_object_property_dump (prop_info=0x0, zv=0x7fb6d1a72348, index=0, key=0x0, level=3) at /usr/src/php/ext/standard/var.c:87
#10 0x0000557ebcfae8b4 in php_var_dump (struc=0x7fb6d1a74e18, level=3) at /usr/src/php/ext/standard/var.c:184
#11 0x0000557ebcfae18a in php_object_property_dump (prop_info=0x7fb6d1a07820, zv=0x7fb6d1a74e18, index=9223601515813480742, key=0x7fb6d1aac040, level=1) at /usr/src/php/ext/standard/var.c:87
#12 0x0000557ebcfae8b4 in php_var_dump (struc=0x7fb6d1a16110, level=1) at /usr/src/php/ext/standard/var.c:184
#13 0x0000557ebcfaec82 in zif_var_dump (execute_data=0x7fb6d1a160c0, return_value=0x7ffc85080d70) at /usr/src/php/ext/standard/var.c:228
#14 0x0000557ebd185394 in ZEND_DO_ICALL_SPEC_RETVAL_UNUSED_HANDLER () at /usr/src/php/Zend/zend_vm_execute.h:1269
#15 0x0000557ebd1f02d8 in execute_ex (ex=0x7fb6d1a16020) at /usr/src/php/Zend/zend_vm_execute.h:53497
#16 0x0000557ebd1f4427 in zend_execute (op_array=0x7fb6d1a02100, return_value=0x0) at /usr/src/php/Zend/zend_vm_execute.h:57617
#17 0x0000557ebd112148 in zend_execute_scripts (type=8, retval=0x0, file_count=3) at /usr/src/php/Zend/zend.c:1679
#18 0x0000557ebd07116c in php_execute_script (primary_file=0x7ffc85083410) at /usr/src/php/main/main.c:2674
#19 0x0000557ebd2077b3 in main (argc=1, argv=0x7ffc85083898) at /usr/src/php/sapi/fpm/fpm/fpm_main.c:1940
(gdb) source /usr/src/php/.gdbinit
(gdb) zbacktrace
[0x7fb6d1a160c0] var_dump(object[0x7fb6d1a16110]) [internal function]
[0x7fb6d1a16020] (main) /var/www/html/index.php:8 
```
</details>

Looks like PHP somehow fails when dumping the opaque GObject pointer. Fix this by sharing the correct typedef across the libvips, GLib and GObject declarations.

This regression was introduced in #146.