### PR TITLE
Avoid “Deprecate dynamic properties” warning in PHP 8.2

### DIFF
--- a/examples/generate_phpdoc.py
+++ b/examples/generate_phpdoc.py
@@ -265,6 +265,8 @@ def generate_auto_doc(filename):
         f.write(' */\n')
         f.write('abstract class ImageAutodoc extends VipsObject\n')
         f.write('{\n')
+        f.write('    abstract public function __set(string $name, $value);\n')
+        f.write('    abstract public function __get(string $name);\n')
         f.write('}\n')
 
 

--- a/src/ImageAutodoc.php
+++ b/src/ImageAutodoc.php
@@ -703,4 +703,6 @@ namespace Jcupitt\Vips;
  */
 abstract class ImageAutodoc extends VipsObject
 {
+    abstract public function __set(string $name, $value);
+    abstract public function __get(string $name);
 }


### PR DESCRIPTION
PHP 8.2 deprecates access to dynamic properties, if not explicitly allowed through __set/__get or an annotation. 
Therefor PHPStan fails for some reason in `\Jcupitt\Vips\ImageAutodoc`, even though it is defined in the `Image` class, see for example here https://github.com/rokka-io/imagine-vips/actions/runs/3236307918/jobs/5301940309 

Adding __set and __get to ImageAutodoc prevents this "fail".

More details about this here https://wiki.php.net/rfc/deprecate_dynamic_properties

(PHP 8.2 is not released yet and "normal" code runs normally, just PHPStan fails currently).

This should also prevent a fatal error, if that is really removed in PHP 9.0 (__set/__get won't be removed, just implicit dynamic properties)