### PR TITLE
Remove native mixed property declarations , not supported by PHP 7.4

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -832,7 +832,7 @@ class Image extends ImageAutodoc implements \ArrayAccess
      * @return Image A new Image.
      */
     public static function newFromMemory(
-        mixed  $data,
+        $data,
         int $width,
         int $height,
         int $bands,


### PR DESCRIPTION
This will make it run with PHP 7.4 again