### PR TITLE
Avoid “Deprecate dynamic properties” warning in PHP 8.2 for the 1.x branch

### DIFF
--- a/examples/generate_phpdoc.py
+++ b/examples/generate_phpdoc.py
@@ -265,6 +265,8 @@ def generate_auto_doc(filename):
         f.write(' */\n')
         f.write('abstract class ImageAutodoc\n')
         f.write('{\n')
+        f.write('    abstract public function __set(string $name, $value);\n')
+        f.write('    abstract public function __get(string $name);\n')
         f.write('}\n')
 
 

--- a/src/ImageAutodoc.php
+++ b/src/ImageAutodoc.php
@@ -699,4 +699,6 @@ namespace Jcupitt\Vips;
  */
 abstract class ImageAutodoc
 {
+    abstract public function __set(string $name, $value);
+    abstract public function __get(string $name);
 }


### PR DESCRIPTION
The same as https://github.com/libvips/php-vips/pull/159, just for the 1.x branch, since that still fails (obviously forgot about that) -> https://github.com/rokka-io/imagine-vips/actions/runs/3457135210/jobs/5770366829

Not sure you still wanna support that, but since it's an easy fix, why not ;)