### PR TITLE
Avoid PHP 8.3 FFI deprecations (fixes #226)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
           - php: '8.0'
           - php: '8.1'
           - php: '8.2'
+          - php: '8.3'
 
     steps:
       - name: Setup PHP

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -14,7 +14,7 @@ abstract class Connection extends VipsObject
 
     public function __construct(\FFI\CData $pointer)
     {
-        $this->pointer = \FFI::cast(FFI::ctypes('VipsConnection'), $pointer);
+        $this->pointer = FFI::vips()->cast(FFI::ctypes('VipsConnection'), $pointer);
         parent::__construct($pointer);
     }
 

--- a/src/GObject.php
+++ b/src/GObject.php
@@ -74,7 +74,7 @@ abstract class GObject
      */
     public function __construct(CData $pointer)
     {
-        $this->pointer = \FFI::cast(FFI::ctypes("GObject"), $pointer);
+        $this->pointer = FFI::vips()->cast(FFI::ctypes("GObject"), $pointer);
     }
 
     public function __destruct()
@@ -135,7 +135,7 @@ abstract class GObject
                     $vi = FFI::gobject()->g_value_get_object(\FFI::addr($params[0]));
                     FFI::gobject()->g_object_ref($vi);
                     $image = new Image($vi);
-                    $pr = \FFI::cast(
+                    $pr = FFI::vips()->cast(
                         FFI::ctypes('VipsProgress'),
                         FFI::gobject()->g_value_get_pointer(\FFI::addr($params[1]))
                     );

--- a/src/GValue.php
+++ b/src/GValue.php
@@ -147,7 +147,7 @@ class GValue
                     $value = [$value];
                 }
                 $n = count($value);
-                $array = \FFI::new("int[$n]");
+                $array = FFI::vips()->new("int[$n]");
                 for ($i = 0; $i < $n; $i++) {
                     $array[$i] = $value[$i];
                 }
@@ -160,7 +160,7 @@ class GValue
                     $value = [$value];
                 }
                 $n = count($value);
-                $array = \FFI::new("double[$n]");
+                $array = FFI::vips()->new("double[$n]");
                 for ($i = 0; $i < $n; $i++) {
                     $array[$i] = $value[$i];
                 }
@@ -187,7 +187,7 @@ class GValue
                 # we need to set the blob to a copy of the data that vips_lib
                 # can own and free
                 $n = strlen($value);
-                $memory = \FFI::new("char[$n]", false, true);
+                $memory = FFI::vips()->new("char[$n]", false, true);
                 \FFI::memcpy($memory, $value, $n);
                 FFI::vips()->
                     vips_value_set_blob_free($this->pointer, $memory, $n);

--- a/src/Image.php
+++ b/src/Image.php
@@ -807,7 +807,7 @@ class Image extends ImageAutodoc implements \ArrayAccess
         $width = count($array[0]);
 
         $n = $width * $height;
-        $a = \FFI::new("double[$n]", true, true);
+        $a = FFI::vips()->new("double[$n]", true, true);
         for ($y = 0; $y < $height; $y++) {
             for ($x = 0; $x < $width; $x++) {
                 $a[$x + $y * $width] = $array[$y][$x];
@@ -1018,7 +1018,7 @@ class Image extends ImageAutodoc implements \ArrayAccess
      */
     public function writeToMemory(): string
     {
-        $p_size = \FFI::new("size_t[1]");
+        $p_size = FFI::vips()->new("size_t[1]");
 
         $pointer = FFI::vips()->
             vips_image_write_to_memory($this->pointer, $p_size);
@@ -1059,7 +1059,7 @@ class Image extends ImageAutodoc implements \ArrayAccess
      */
     public function writeToArray(): array
     {
-        $p_size = \FFI::new("size_t[1]");
+        $p_size = FFI::vips()->new("size_t[1]");
 
         $pointer = FFI::vips()->
             vips_image_write_to_memory($this->pointer, $p_size);

--- a/src/Image.php
+++ b/src/Image.php
@@ -500,7 +500,7 @@ class Image extends ImageAutodoc implements \ArrayAccess
      */
     public function __construct(\FFI\CData $pointer)
     {
-        $this->pointer = \FFI::cast(FFI::ctypes("VipsImage"), $pointer);
+        $this->pointer = FFI::vips()->cast(FFI::ctypes("VipsImage"), $pointer);
         parent::__construct($pointer);
     }
 
@@ -921,7 +921,9 @@ class Image extends ImageAutodoc implements \ArrayAccess
      */
     public static function findLoadSource(Source $source): ?string
     {
-        return FFI::vips()->vips_foreign_find_load_source(\FFI::cast(FFI::ctypes('VipsSource'), $source->pointer));
+        return FFI::vips()->vips_foreign_find_load_source(
+            FFI::vips()->cast(FFI::ctypes('VipsSource'), $source->pointer)
+        );
     }
 
     /**
@@ -1068,7 +1070,7 @@ class Image extends ImageAutodoc implements \ArrayAccess
         // wrap pointer up as a C array of the right type
         $type_name = FFI::ftypes($this->format);
         $n = $this->width * $this->height * $this->bands;
-        $array = \FFI::cast("{$type_name}[$n]", $pointer);
+        $array = FFI::vips()->cast("{$type_name}[$n]", $pointer);
 
         // copy to PHP memory as a flat array
         $result = [];

--- a/src/Interpolate.php
+++ b/src/Interpolate.php
@@ -62,7 +62,7 @@ class Interpolate extends VipsObject
 
     public function __construct(\FFI\CData $pointer)
     {
-        $this->pointer = \FFI::cast(FFI::ctypes("VipsInterpolate"), $pointer);
+        $this->pointer = FFI::vips()->cast(FFI::ctypes("VipsInterpolate"), $pointer);
 
         parent::__construct($pointer);
     }

--- a/src/Introspect.php
+++ b/src/Introspect.php
@@ -105,7 +105,7 @@ class Introspect
         $p_flags = FFI::vips()->new("int*[1]");
         $p_n_args = FFI::vips()->new("int[1]");
         $result = FFI::vips()->vips_object_get_args(
-            \FFI::cast(FFI::ctypes("VipsObject"), $operation->pointer),
+            FFI::vips()->cast(FFI::ctypes("VipsObject"), $operation->pointer),
             $p_names,
             $p_flags,
             $p_n_args

--- a/src/Source.php
+++ b/src/Source.php
@@ -14,7 +14,7 @@ class Source extends Connection
 
     public function __construct(\FFI\CData $pointer)
     {
-        $this->pointer = \FFI::cast(FFI::ctypes('VipsSource'), $pointer);
+        $this->pointer = FFI::vips()->cast(FFI::ctypes('VipsSource'), $pointer);
         parent::__construct($pointer);
     }
 

--- a/src/Source.php
+++ b/src/Source.php
@@ -67,7 +67,7 @@ class Source extends Connection
         # we need to set the memory to a copy of the data that vips_lib
         # can own and free
         $n = strlen($data);
-        $memory = \FFI::new("char[$n]", false, true);
+        $memory = FFI::vips()->new("char[$n]", false, true);
         \FFI::memcpy($memory, $data, $n);
         $pointer = FFI::vips()->vips_source_new_from_memory($memory, $n);
 

--- a/src/Target.php
+++ b/src/Target.php
@@ -14,7 +14,7 @@ class Target extends Connection
 
     public function __construct(\FFI\CData $pointer)
     {
-        $this->pointer = \FFI::cast(FFI::ctypes('VipsTarget'), $pointer);
+        $this->pointer = FFI::vips()->cast(FFI::ctypes('VipsTarget'), $pointer);
         parent::__construct($pointer);
     }
 

--- a/src/VipsObject.php
+++ b/src/VipsObject.php
@@ -68,8 +68,8 @@ abstract class VipsObject extends GObject
 
     public function __construct(\FFI\CData $pointer)
     {
-        $this->pointer = \FFI::cast(FFI::ctypes("VipsObject"), $pointer);
-        $this->gObject = \FFI::cast(FFI::ctypes("GObject"), $pointer);
+        $this->pointer = FFI::vips()->cast(FFI::ctypes("VipsObject"), $pointer);
+        $this->gObject = FFI::vips()->cast(FFI::ctypes("GObject"), $pointer);
 
         parent::__construct($pointer);
     }


### PR DESCRIPTION
This probably isn't the ideal way (the ideal way would be dependency injection), but it's fast and backward-compatible.
I tested this briefly on my machine and it seemed to work well.