### PR TITLE
fix: Add `VIPSHOME` as a potential direct library location

### DIFF
--- a/src/FFI.php
+++ b/src/FFI.php
@@ -267,6 +267,7 @@ class FFI
 
         $vipshome = getenv("VIPSHOME");
         if ($vipshome) {
+            $libraryPaths[] = $vipshome . '/';
             // lib<qual>/ predicates lib/
             $libraryPaths[] = $vipshome . ($is_64bits ? "/lib64/" : "/lib32/");
             // lib/ is always searched


### PR DESCRIPTION
This PR introduces a modification to support `VIPSHOME` as a direct library location. This addresses #232 and is particularly useful in scenarios where a portable shared binary of `libvips` is distributed within the PHP project, eliminating the need to modify the system path.