### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,18 @@
+* text=auto
+* eol=lf
+
+.git                export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+CREDITS             export-ignore
+phpcs-ruleset.xml   export-ignore
+phpdoc.xml          export-ignore
+phpunit.xml         export-ignore
+scrutinizer.yml     export-ignore
+.github             export-ignore
+examples            export-ignore
+tests               export-ignore
+API-1.0.0           export-ignore
+RELEASE-2.0.0       export-ignore
+CONTRIBUTING.md     export-ignore
+CHANGELOG.md        export-ignore


### PR DESCRIPTION
This PR adds a .gitattributes file to exclude specific files and directories from exports/installing composer package. 

**Purpose:**

Keeps repository metadata and tooling files out of distribution packages.
Follows best practices for cleaner project exports.

**Impact:**

No runtime changes — this only affects repository operations like git archive.