### PR TITLE
CI: run `apt-get update` before installing libvips

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install vips
-        run: sudo apt install -y --no-install-recommends libvips
+      - name: Install libvips
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends libvips
 
       - name: Install composer dependencies
         run: |


### PR DESCRIPTION
See:
https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/customizing-github-hosted-runners#installing-software-on-ubuntu-runners

and the failures in PR #272.