### PR TITLE
Fix mem leak in `Source::newFromMemory()`

### DIFF
--- a/src/FFI.php
+++ b/src/FFI.php
@@ -539,6 +539,8 @@ void vips_value_set_array_image (GValue *value, int n);
 typedef void (*FreeFn)(void* a);
 void vips_value_set_blob (GValue* value,
     FreeFn free_fn, void* data, size_t length);
+void* vips_blob_copy (const void *data, size_t length);
+void vips_area_unref (void *area);
 
 const char* vips_value_get_ref_string (const GValue* value,
     size_t* length);
@@ -760,8 +762,7 @@ typedef struct _VipsSource {
 
 VipsSource* vips_source_new_from_descriptor (int descriptor);
 VipsSource* vips_source_new_from_file (const char* filename);
-VipsSource* vips_source_new_from_memory (const void* data,
-    size_t size);
+VipsSource* vips_source_new_from_blob (void* blob);
 
 typedef struct _VipsSourceCustom {
     VipsSource parent_object;


### PR DESCRIPTION
Found while running the test suite with LeakSanitizer.

<details>
  <summary>Details</summary>

```console
=================================================================
==1212185==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 2149584 byte(s) in 4 object(s) allocated from:
    #0 0x7fa8d34dab98 in malloc (/usr/lib64/llvm20/bin/../../../lib/clang/20/lib/x86_64-redhat-linux-gnu/libclang_rt.asan.so+0xdab98) (BuildId: aa6231e817f72469c44a6c6cee9f0694a87db7fb)
    #1 0x0000013099d3 in __zend_malloc /home/kleisauke/php-src/Zend/zend_alloc.c:3280:14
    #2 0x0000008a3233 in zim_FFI_new /home/kleisauke/php-src/ext/ffi/ffi.c:3915:8
    #3 0x00000151f0b1 in ZEND_DO_FCALL_SPEC_RETVAL_USED_HANDLER /home/kleisauke/php-src/Zend/zend_vm_execute.h:2025:4
    #4 0x0000014466dc in execute_ex /home/kleisauke/php-src/Zend/zend_vm_execute.h:58593:7
    #5 0x000001699b60 in zend_generator_resume /home/kleisauke/php-src/Zend/zend_generators.c:822:3
    #6 0x0000016a21aa in zend_generator_iterator_move_forward /home/kleisauke/php-src/Zend/zend_generators.c:1154:2
    #7 0x000001669501 in zend_fe_fetch_object_helper_SPEC /home/kleisauke/php-src/Zend/zend_vm_execute.h:2953:4
    #8 0x00000154aed7 in ZEND_FE_FETCH_R_SPEC_VAR_HANDLER /home/kleisauke/php-src/Zend/zend_vm_execute.h:23002:3
    #9 0x0000014466dc in execute_ex /home/kleisauke/php-src/Zend/zend_vm_execute.h:58593:7
    #10 0x000001446e5d in zend_execute /home/kleisauke/php-src/Zend/zend_vm_execute.h:64245:2
    #11 0x000001806207 in zend_execute_script /home/kleisauke/php-src/Zend/zend.c:1934:3
    #12 0x00000110846f in php_execute_script_ex /home/kleisauke/php-src/main/main.c:2575:13
    #13 0x000001108938 in php_execute_script /home/kleisauke/php-src/main/main.c:2615:9
    #14 0x00000180c030 in do_cli /home/kleisauke/php-src/sapi/cli/php_cli.c:935:5
    #15 0x00000180a419 in main /home/kleisauke/php-src/sapi/cli/php_cli.c:1310:18
    #16 0x7fa8d2ea35f4 in __libc_start_call_main (/usr/lib64/../lib64/libc.so.6+0x35f4) (BuildId: 2b3c02fe7e4d3811767175b6f323692a10a4e116)
    #17 0x7fa8d2ea36a7 in __libc_start_main@GLIBC_2.2.5 (/usr/lib64/../lib64/libc.so.6+0x36a7) (BuildId: 2b3c02fe7e4d3811767175b6f323692a10a4e116)
    #18 0x0000004047b4 in _start (/opt/php/bin/php+0x4047b4) (BuildId: 0e33124a4bd60661ceaa03f37bd3b29e06bdd02d)

SUMMARY: AddressSanitizer: 2149584 byte(s) leaked in 4 allocation(s).
```
</details>
